### PR TITLE
add a public method to return the kernel

### DIFF
--- a/Test/Units/WebTestCase.php
+++ b/Test/Units/WebTestCase.php
@@ -180,4 +180,14 @@ abstract class WebTestCase extends Test
 
         return $dir;
     }
+
+    /**
+     * return Kernel
+     *
+     * @return Object HttpKernelInterface
+     */
+    public function getKernel()
+    {
+        return $this->kernel;
+    }
 }


### PR DESCRIPTION
I need this to test validator 

```

validator = $client->getKernel()->getContainer()->get('validator');
```

can be usefull for other usage I guess
