### PR TITLE
Add a kernelReset attribute to controle kernel reseting on client creation.

### DIFF
--- a/Test/Units/WebTestCase.php
+++ b/Test/Units/WebTestCase.php
@@ -76,6 +76,18 @@ abstract class WebTestCase extends Test
 
     }
 
+    protected function setClassAnnotations(atoum\annotations\extractor $extractor)
+    {
+        parent::setClassAnnotations($extractor);
+
+        $test = $this;
+
+        $extractor
+            ->setHandler('resetKernel', function($value) use ($test) { $test->enableKernelReset(atoum\annotations\extractor::toBoolean($value)); })
+            ->setHandler('noResetKernel', function() use ($test) { $test->enableKernelReset(false); })
+        ;
+    }
+
     /**
      * @param \Symfony\Bundle\FrameworkBundle\Client $client
      * @param \Symfony\Component\DomCrawler\Crawler  $crawler


### PR DESCRIPTION
During tests of controllers with a database connection inside, the connection is lost by kernel reseting.
This PR allows to disable kernel reseting and avoid this problem.

Note : I don't know how to test it.
