### PR TITLE
Loop support

### DIFF
--- a/Command/AtoumCommand.php
+++ b/Command/AtoumCommand.php
@@ -50,10 +50,11 @@ EOF
                 )
                 ->addArgument('bundles', InputArgument::IS_ARRAY, 'Launch tests of these bundles.')
                 ->addOption('bootstrap-file', 'bf', InputOption::VALUE_REQUIRED, 'Define the bootstrap file')
-                ->addOption('no-code-coverage', null, InputOption::VALUE_NONE, 'Disable code coverage (big speed increase)')
+                ->addOption('no-code-coverage', 'ncc', InputOption::VALUE_NONE, 'Disable code coverage (big speed increase)')
                 ->addOption('max-children-number', 'mcn', InputOption::VALUE_REQUIRED, 'Maximum number of sub-processus which will be run simultaneously')
                 ->addOption('loop', 'l', InputOption::VALUE_NONE, 'Enables Atoum loop mode')
                 ->addOption('--force-terminal', '', InputOption::VALUE_NONE, '')
+                ->addOption('--score-file', '', InputOption::VALUE_REQUIRED, '')
         ;
     }
 
@@ -106,6 +107,10 @@ EOF
 
         if ($input->getOption('force-terminal')) {
             $this->setAtoumArgument('--force-terminal');
+        }
+
+        if ($input->getOption('score-file')) {
+            $this->setAtoumArgument('--score-file', $input->getOption('score-file'));
         }
 
         $runner->run($this->getAtoumArguments());

--- a/Command/AtoumCommand.php
+++ b/Command/AtoumCommand.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use atoum\AtoumBundle\Configuration\Bundle as BundleConfiguration;
-use mageekguy\atoum\scripts\runner;
+use atoum\AtoumBundle\Scripts\Runner;
 
 /**
  * AtoumCommand
@@ -52,6 +52,8 @@ EOF
                 ->addOption('bootstrap-file', 'bf', InputOption::VALUE_REQUIRED, 'Define the bootstrap file')
                 ->addOption('no-code-coverage', null, InputOption::VALUE_NONE, 'Disable code coverage (big speed increase)')
                 ->addOption('max-children-number', 'mcn', InputOption::VALUE_REQUIRED, 'Maximum number of sub-processus which will be run simultaneously')
+                ->addOption('loop', 'l', InputOption::VALUE_NONE, 'Enables Atoum loop mode')
+                ->addOption('--force-terminal', '', InputOption::VALUE_NONE, '')
         ;
     }
 
@@ -60,7 +62,7 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $runner = new runner('atoum');
+        $runner = new Runner('atoum');
 
         $bundles = $input->getArgument('bundles');
         if (count($bundles) > 0) {
@@ -96,6 +98,14 @@ EOF
 
         if ($input->getOption('max-children-number')) {
             $this->setAtoumArgument('--max-children-number', (int) $input->getOption('max-children-number'));
+        }
+
+        if ($input->getOption('loop')) {
+            $this->setAtoumArgument('--loop');
+        }
+
+        if ($input->getOption('force-terminal')) {
+            $this->setAtoumArgument('--force-terminal');
         }
 
         $runner->run($this->getAtoumArguments());

--- a/Scripts/Runner.php
+++ b/Scripts/Runner.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace atoum\AtoumBundle\Scripts;
+
+use \mageekguy\atoum\scripts\runner as BaseRunner;
+use mageekguy\atoum\cli;
+use mageekguy\atoum\php;
+
+class Runner extends BaseRunner
+{
+
+    protected function loop()
+    {
+        $php = new php();
+
+        foreach ($_SERVER['argv'] as $arg) {
+            switch ($arg) {
+                // Remove the loop option
+                case '-l':
+                case '--loop':
+                    break;
+                default:
+                    $php->addOption($arg);
+            }
+        }
+
+        if ($this->cli->isTerminal() === true) {
+            $php->addOption('--force-terminal');
+        }
+
+        while ($this->canRun() === true) {
+            passthru((string) $php);
+
+            if ($this->loop === false || $this->runAgain() === false) {
+                $this->stopRun();
+            }
+        }
+
+        return $this;
+    }
+
+}

--- a/Scripts/Runner.php
+++ b/Scripts/Runner.php
@@ -2,7 +2,7 @@
 
 namespace atoum\AtoumBundle\Scripts;
 
-use \mageekguy\atoum\scripts\runner as BaseRunner;
+use mageekguy\atoum\scripts\runner as BaseRunner;
 use mageekguy\atoum\cli;
 use mageekguy\atoum\php;
 

--- a/Scripts/Runner.php
+++ b/Scripts/Runner.php
@@ -28,6 +28,30 @@ class Runner extends BaseRunner
             $php->addOption('--force-terminal');
         }
 
+        $addScoreFile = false;
+
+        foreach ($this->argumentsParser->getValues() as $argument => $values) {
+            switch ($argument)
+            {
+                case '-sf':
+                case '--score-file':
+                    $addScoreFile = true;
+                    break;
+            }
+        }
+
+        if ($this->scoreFile === null) {
+            $this->scoreFile = sys_get_temp_dir() . '/atoum.score';
+
+            @unlink($this->scoreFile);
+
+            $addScoreFile = true;
+        }
+
+        if ($addScoreFile === true) {
+            $php->addOption(sprintf('--score-file=%s', $this->scoreFile));
+        }
+
         while ($this->canRun() === true) {
             passthru((string) $php);
 


### PR DESCRIPTION
The lack of "loop mode" is the first thing I noticed with this bundle.

I have overriden `mageekguy\atoum\scripts\runner::loop()` to kind of fix the `passthru()` call, calling back the Symfony command. 
As arguments/options handling of atoum and symfony commands is a bit different, I simply and roughly fed back all the original options and arguments to the command, handling only score file as in the original `loop()` function.

I guess this is a bit dirty, and I don't know everything I'm doing :dog:
