### PR TITLE
removing all replace statements in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,10 +28,6 @@
     "require-dev": {
         "symfony/form": "2.*"
     },
-    "replace": {
-        "rezzza/atoum-bundle": "*",
-        "jedi/atoum-bundle": "*"
-    },
     "autoload": {
         "psr-0": {
             "atoum\\AtoumBundle": ""


### PR DESCRIPTION
Hello,

As the AtoumBundle as been moved to atoum namespace for a long time, I suggest to remove the old "replace" statements, which causes a quiet long delay when doing a `composer update` with a lot of dependencies.

Here are exemples of my composer update for 2 projects :

```
[132.5MB/13.67s] Reading /Users/fvilpoix/.composer/cache/repo/https---packagist.org/provider-symfony$propel1-bridge.json from cache
[133.9MB/14.26s] Reading /Users/fvilpoix/.composer/cache/repo/https---packagist.org/provider-symfony$proxy-manager-bridge.json from cache
[134.5MB/14.47s] Reading /Users/fvilpoix/.composer/cache/repo/https---packagist.org/provider-symfony$expression-language.json from cache
[134.7MB/14.55s] Reading /Users/fvilpoix/.composer/cache/repo/https---packagist.org/provider-symfony$security-acl.json from cache
[135.0MB/14.57s] Reading /Users/fvilpoix/.composer/cache/repo/https---packagist.org/provider-symfony$security-http.json from cache
[515.4MB/64.98s] Reading /Users/fvilpoix/.composer/cache/repo/https---packagist.org/provider-jedi$atoum-bundle.json from cache
[515.4MB/64.98s] Reading /Users/fvilpoix/.composer/cache/repo/https---packagist.org/provider-rezzza$atoum-bundle.json from cache
[515.5MB/64.98s] Reading /Users/fvilpoix/.composer/cache/repo/https---packagist.org/provider-mageekguy$atoum.json from cache
```

or in a small project :

```
[100.9MB/9.01s] Reading /Users/fvilpoix/.composer/cache/repo/https---packagist.org/provider-symfony$security-acl.json from cache
[101.2MB/9.04s] Reading /Users/fvilpoix/.composer/cache/repo/https---packagist.org/provider-symfony$security-http.json from cache
[134.5MB/11.16s] Reading /Users/fvilpoix/.composer/cache/repo/https---packagist.org/provider-symfony$doctrine-abstract-bundle.json from cache
[285.9MB/25.01s] Reading /Users/fvilpoix/.composer/cache/repo/https---packagist.org/provider-jedi$atoum-bundle.json from cache
[286.0MB/25.01s] Reading /Users/fvilpoix/.composer/cache/repo/https---packagist.org/provider-rezzza$atoum-bundle.json from cache
[286.0MB/25.01s] Reading /Users/fvilpoix/.composer/cache/repo/https---packagist.org/provider-mageekguy$atoum.json from cache
```

Thx :)
