### PR TITLE
Adds the ability to test Symfony commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,42 @@ class helloWorld extends Units\WebTestCase
 }
 ```
 
+## Command test case
+
+You can also easily test a command:
+
+```php
+<?php
+
+namespace My\Bundle\FoobarBundle\Tests\Units\Command;
+
+use atoum\AtoumBundle\Test\Units as AtoumBundle;
+use mageekguy\atoum;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+// Assuming that this command will display "Success" if succes, and returns a boolean
+use My\Bundle\FoobarBundle\Tests\Units\Command\FoobarCommand as Base;
+
+class FoobarCommand extends AtoumBundle\CommandTestCase
+{
+    public function testExecute()
+    {
+        $this
+            ->given(
+                $command = new Base()
+            )
+            ->if($commandTester = $this->createCommandTester($command))
+            ->then
+                ->boolean($commandTester->execute())
+                    ->isTrue()
+                ->string($commandTester->getDisplay())
+                    ->contains("Success")
+        ;
+    }
+}
+```
+
 ### Known issues
 
 - The path of the AppKernel cannot be found, override the method ```getKernelDirectory```

--- a/Test/Units/CommandTestCase.php
+++ b/Test/Units/CommandTestCase.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace atoum\AtoumBundle\Test\Units;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class CommandTestCase extends Test
+{
+    /**
+     * Create a CommandTester instance to test commands
+     *
+     * @param ContainerAwareCommand $command
+     *
+     * @return CommandTester
+     */
+    public function createCommandTester(ContainerAwareCommand $command)
+    {
+        // Create Kernel
+        $kernel = $this->getKernel();
+        $kernel->boot();
+
+        // Create application
+        $application = new Application($kernel);
+        $application->add($command);
+
+        // Create command tester for the given command
+        $commandTester = new CommandTester(
+            $application->find($command->getName())
+        );
+
+        return $commandTester;
+    }
+}
+

--- a/Test/Units/Test.php
+++ b/Test/Units/Test.php
@@ -4,9 +4,21 @@ namespace atoum\AtoumBundle\Test\Units;
 
 use Faker;
 use mageekguy\atoum;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
 
 abstract class Test extends atoum\test
 {
+    /** @var $string */
+    protected $class;
+
+    /** @var \Symfony\Component\HttpKernel\HttpKernelInterface */
+    protected $kernel;
+
+    /** @var boolean */
+    protected $kernelReset = true;
+
     /**
      * {@inheritdoc}
      */
@@ -39,6 +51,23 @@ abstract class Test extends atoum\test
     }
 
     /**
+     * @param atoum\annotations\extractor $extractor
+     *
+     * @return $this|void
+     */
+    protected function setClassAnnotations(atoum\annotations\extractor $extractor)
+    {
+        parent::setClassAnnotations($extractor);
+
+        $test = $this;
+
+        $extractor
+            ->setHandler('resetKernel', function ($value) use ($test) { $test->enableKernelReset(atoum\annotations\extractor::toBoolean($value)); })
+            ->setHandler('noResetKernel', function () use ($test) { $test->enableKernelReset(false); })
+        ;
+    }
+
+    /**
      * @param string $locale
      *
      * @return Faker\Generator
@@ -46,5 +75,100 @@ abstract class Test extends atoum\test
     public function getFaker($locale = 'en_US')
     {
         return Faker\Factory::create($locale);
+    }
+
+    /**
+     * Creates a Kernel.
+     *
+     * Available options:
+     *
+     *  * environment
+     *  * debug
+     *
+     * @param array $options An array of options
+     *
+     * @return HttpKernelInterface A HttpKernelInterface instance
+     */
+    protected function createKernel(array $options = array())
+    {
+        if (null === $this->class) {
+            $this->class = $this->getKernelClass();
+        }
+
+        return new $this->class(
+            isset($options['environment']) ? $options['environment'] : 'test',
+            isset($options['debug']) ? $options['debug'] : true
+        );
+    }
+
+    /**
+     * Attempts to guess the kernel location.
+     *
+     * When the Kernel is located, the file is required.
+     *
+     * @throws \RuntimeException
+     *
+     * @return string The Kernel class name
+     */
+    protected function getKernelClass()
+    {
+        $dir = $this->getKernelDirectory();
+
+        $finder = new Finder();
+        $finder->name('*Kernel.php')->depth(0)->in($dir);
+        $results = iterator_to_array($finder);
+        if (!count($results)) {
+            throw new \RuntimeException(sprintf('Impossible to find a Kernel file, override the %1$s::getKernelDirectory() method or %1$s::createKernel() method.', get_class($this)));
+        }
+
+        $file = current($results);
+        $class = $file->getBasename('.php');
+
+        require_once $file;
+
+        return $class;
+    }
+
+    /**
+     * Override this method if needed
+     *
+     * @return string
+     */
+    protected function getKernelDirectory()
+    {
+        $dir = getcwd().'/app';
+        if (!is_dir($dir)) {
+            $dir = dirname($dir);
+        }
+
+        return $dir;
+    }
+
+    /**
+     * return Kernel
+     *
+     * @return Object HttpKernelInterface
+     */
+    public function getKernel()
+    {
+        if(null === $this->kernel) {
+            $this->kernel = $this->createKernel();
+        }
+
+        return $this->kernel;
+    }
+
+    /**
+     * Enable or disable kernel reseting on client creation.
+     *
+     * @param boolean $kernelReset
+     *
+     * @return WebTestCase
+     */
+    public function enableKernelReset($kernelReset)
+    {
+        $this->kernelReset = (boolean) $kernelReset;
+
+        return $this;
     }
 }

--- a/Test/Units/WebTestCase.php
+++ b/Test/Units/WebTestCase.php
@@ -3,8 +3,6 @@
 namespace atoum\AtoumBundle\Test\Units;
 
 use Symfony\Bundle\FrameworkBundle\Client;
-use Symfony\Component\Finder\Finder;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 use atoum\AtoumBundle\Test\Asserters;
 use mageekguy\atoum;
 use Symfony\Component\CssSelector\CssSelector;
@@ -17,15 +15,6 @@ use Symfony\Component\CssSelector\CssSelector;
  */
 abstract class WebTestCase extends Test
 {
-    /** @var $string */
-    protected $class;
-
-    /** @var \Symfony\Component\HttpKernel\HttpKernelInterface */
-    protected $kernel;
-
-    /** @var boolean */
-    protected $kernelReset = true;
-
     /**
      * {@inheritdoc}
      */
@@ -80,23 +69,6 @@ abstract class WebTestCase extends Test
     }
 
     /**
-     * @param atoum\annotations\extractor $extractor
-     *
-     * @return $this|void
-     */
-    protected function setClassAnnotations(atoum\annotations\extractor $extractor)
-    {
-        parent::setClassAnnotations($extractor);
-
-        $test = $this;
-
-        $extractor
-            ->setHandler('resetKernel', function ($value) use ($test) { $test->enableKernelReset(atoum\annotations\extractor::toBoolean($value)); })
-            ->setHandler('noResetKernel', function () use ($test) { $test->enableKernelReset(false); })
-        ;
-    }
-
-    /**
      * @param \Symfony\Bundle\FrameworkBundle\Client $client
      * @param \Symfony\Component\DomCrawler\Crawler  $crawler
      * @param string                                 $method
@@ -145,96 +117,5 @@ abstract class WebTestCase extends Test
         }
 
         return $client;
-    }
-
-    /**
-     * Creates a Kernel.
-     *
-     * Available options:
-     *
-     *  * environment
-     *  * debug
-     *
-     * @param array $options An array of options
-     *
-     * @return HttpKernelInterface A HttpKernelInterface instance
-     */
-    protected function createKernel(array $options = array())
-    {
-        if (null === $this->class) {
-            $this->class = $this->getKernelClass();
-        }
-
-        return new $this->class(
-            isset($options['environment']) ? $options['environment'] : 'test',
-            isset($options['debug']) ? $options['debug'] : true
-        );
-    }
-
-    /**
-     * Attempts to guess the kernel location.
-     *
-     * When the Kernel is located, the file is required.
-     *
-     * @throws \RuntimeException
-     *
-     * @return string The Kernel class name
-     */
-    protected function getKernelClass()
-    {
-        $dir = $this->getKernelDirectory();
-
-        $finder = new Finder();
-        $finder->name('*Kernel.php')->depth(0)->in($dir);
-        $results = iterator_to_array($finder);
-        if (!count($results)) {
-            throw new \RuntimeException('Impossible to find a Kernel file, override the WebTestCase::getKernelDirectory() method or WebTestCase::createKernel() method.');
-        }
-
-        $file = current($results);
-        $class = $file->getBasename('.php');
-
-        require_once $file;
-
-        return $class;
-    }
-
-    /**
-     * Override this method if needed
-     *
-     * @return string
-     */
-    protected function getKernelDirectory()
-    {
-        $dir = getcwd().'/app';
-        if (!is_dir($dir)) {
-            $dir = dirname($dir);
-        }
-
-        return $dir;
-    }
-
-    /**
-     * return Kernel
-     *
-     * @return Object HttpKernelInterface
-     */
-    public function getKernel()
-    {
-        return $this->kernel;
-    }
-
-    /**
-     * Enable or disable kernel reseting on client creation.
-     *
-     * @param boolean $kernelReset
-     *
-     * @return WebTestCase
-     */
-    public function enableKernelReset($kernelReset)
-    {
-        $this->kernelReset = (boolean) $kernelReset;
-
-        return $this;
     }
 }

--- a/tests/units/Test/Units/CommandTestCase.php
+++ b/tests/units/Test/Units/CommandTestCase.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace atoum\AtoumBundle\tests\units\Test\Units;
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+use mageekguy\atoum;
+
+class CommandTestCase extends atoum\test
+{
+    public function testClass()
+    {
+        $this->testedClass->isSubclassOf('\\atoum\\AtoumBundle\\Test\\Units\\Test');
+    }
+
+    public function testCreateCommandTester()
+    {
+        $this
+            ->given(
+                $command = new \mock\Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand($commandName = uniqid()),
+                $command->getMockController()->run = $status = uniqid()
+            )
+            ->given(
+                $kernel      = new \mock\Symfony\Component\HttpKernel\KernelInterface(),
+                $application = new \mock\Symfony\Bundle\FrameworkBundle\Console\Application($kernel)
+            )
+            ->given(
+                $object = new \mock\atoum\AtoumBundle\Test\Units\CommandTestCase(),
+                $object->getMockController()->getKernel = $kernel
+            )
+            ->if($commandTester = $object->createCommandTester($command))
+            ->then
+                ->object($commandTester)
+                    ->isInstanceOf('\\Symfony\\Component\\Console\\Tester\\CommandTester')
+                ->variable($commandTester->execute(array()))
+                    ->isEqualTo($status)
+        ;
+    }
+}
+


### PR DESCRIPTION
With this commit, its become possible to easily test commands

Exemple : 
```php
<?php

namespace My\Bundle\FoobarBundle\Tests\Units\Command;

use atoum\AtoumBundle\Test\Units as AtoumBundle;
use mageekguy\atoum;
use Symfony\Bundle\FrameworkBundle\Console\Application;
use Symfony\Component\Console\Tester\CommandTester;

// Assuming that this command will display "Success" if succes, and returns a boolean
use My\Bundle\FoobarBundle\Tests\Units\Command\FoobarCommand as Base;

class FoobarCommand extends AtoumBundle\CommandTestCase
{
    public function testExecute()
    {
        $this
            ->given(
                $command = new Base()
            )
            ->if($commandTester = $this->createCommandTester($command))
            ->then
                ->boolean($commandTester->execute())
                    ->isTrue()
                ->string($commandTester->getDisplay())
                    ->contains("Success")
        ;
    }
}
```