### PR TITLE
fix compatibility with atoum 2.4.*

### DIFF
--- a/Test/Units/CommandTestCase.php
+++ b/Test/Units/CommandTestCase.php
@@ -4,7 +4,6 @@ namespace atoum\AtoumBundle\Test\Units;
 
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class CommandTestCase extends Test

--- a/Test/Units/Test.php
+++ b/Test/Units/Test.php
@@ -24,9 +24,9 @@ abstract class Test extends atoum\test
      */
     public function __construct(atoum\adapter $adapter = null, atoum\annotations\extractor $annotationExtractor = null, atoum\asserter\generator $asserterGenerator = null, atoum\test\assertion\manager $assertionManager = null, \closure $reflectionClassFactory = null)
     {
-        $this->setTestNamespace('Tests\Units');
-
         parent::__construct($adapter, $annotationExtractor, $asserterGenerator, $assertionManager, $reflectionClassFactory);
+
+        $this->setTestNamespace('Tests\Units');
     }
 
     /**


### PR DESCRIPTION
AtoumBundle make error with atoum 2.4.1

```
Fatal error: Call to a member function isRegex() on null in /home/vagrant/dev/portailsts/vendor/atoum/atoum/classes/test.php on line 801
```

This PR fix the bug.
