### PR TITLE
Symfony3 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/framework-bundle": "2.*",
-        "symfony/console": "2.*",
-        "symfony/finder": "2.*",
-        "symfony/dom-crawler": "2.*",
-        "symfony/css-selector": "2.*",
+        "symfony/framework-bundle": "2.*|^3.0",
+        "symfony/console": "2.*|^3.0",
+        "symfony/finder": "2.*|^3.0",
+        "symfony/dom-crawler": "2.*|^3.0",
+        "symfony/css-selector": "2.*|^3.0",
         "atoum/atoum": ">=1.0,<3.0",
         "fzaninotto/faker": "1.*"
     },

--- a/tests/units/DomCrawler/DOMNode.php
+++ b/tests/units/DomCrawler/DOMNode.php
@@ -77,11 +77,13 @@ class DOMNode extends atoum\test
             ->and($object = new TestedClass($crawler))
             ->then
                 ->object($children = $object->children())->isInstanceOf('\\Symfony\\Component\\DomCrawler\\Crawler')
-                ->boolean($children->contains($child))->isTrue()
+                ->object($children->getNode(0))
+                    ->isEqualTo($child)
             ->if($object = new TestedClass($node))
             ->then
                 ->object($children = $object->children())->isInstanceOf('\\Symfony\\Component\\DomCrawler\\Crawler')
-                ->boolean($children->contains($child))->isTrue()
+                ->object($children->getNode(0))
+                    ->isEqualTo($child)
         ;
     }
 }


### PR DESCRIPTION
`Symfony\Component\DomCrawler\Crawler` changes in 3.0 : it doesn't implement anymore `\SplObjectStorage` so we can't rely anymore on `contains` method in our tests. 

I don't really know this component, if someone have a better idea.. ? ping @jubianchi 