### PR TITLE
Fix #96: CssSelector removed in symfony 3

### DIFF
--- a/Test/Units/WebTestCase.php
+++ b/Test/Units/WebTestCase.php
@@ -53,10 +53,13 @@ abstract class WebTestCase extends Test
             ->setHandler(
                 'crawler',
                 function ($strict = false) use (& $crawler, $generator, $test) {
-                    if ($strict) {
-                        CssSelector::enableHtmlExtension();
-                    } else {
-                        CssSelector::disableHtmlExtension();
+                    // BC with Symfony <=2.8
+                    if (class_exists('Symfony\Component\CssSelector\CssSelector')) {
+                        if ($strict) {
+                            CssSelector::enableHtmlExtension();
+                        } else {
+                            CssSelector::disableHtmlExtension();
+                        }
                     }
 
                     return $generator->getAsserterInstance('\\atoum\\AtoumBundle\\Test\\Asserters\\Crawler', array($crawler), $test);


### PR DESCRIPTION
This patch ensures `WebTestCase` is compatible with Symfony 2 and 3.

`Symfony\Component\CssSelector\CssSelector` class was removed in Symfony 3 in favor of `Symfony\Component\CssSelector\CssSelectorConverter`. In Symfony 3, the crawler automatically adds HTML support if necessary.