### PR TITLE
Allow the bundle to use atoum 3.x to be compatible with PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
     - 5.5
     - 5.6
     - 7.0
-
+    - 7.1
 
 cache:
   directories:
@@ -21,7 +21,8 @@ env:
 
 script:
   - composer update $COMPOSER_PREFER
-  - "[[ \"$TRAVIS_PHP_VERSION\" != '5.3' && \"$TRAVIS_PHP_VERSION\" != '5.4' ]] && composer require --dev 'atoum/reports-extension:^2.0.1' || true"
+  - "[[ \"$TRAVIS_PHP_VERSION\" == '7.1' ]] && composer require 'atoum/atoum:dev-3.0.x-dev' || true"
+  - "[[ \"$TRAVIS_PHP_VERSION\" != '5.3' && \"$TRAVIS_PHP_VERSION\" != '5.4' && \"$TRAVIS_PHP_VERSION\" != '7.1' ]] && composer require --dev 'atoum/reports-extension:^2.0.1' || true"
   - bin/atoum -ncc
 
 notifications:

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "symfony/finder": ">=2.3.0|^3.0",
         "symfony/dom-crawler": ">=2.3.0|^3.0",
         "symfony/css-selector": ">=2.3.0|^3.0",
-        "atoum/atoum": ">=2.1.0,<3.0",
+        "atoum/atoum": "^2.1.0|^3.0",
         "fzaninotto/faker": "1.*"
     },
     "require-dev": {


### PR DESCRIPTION
Atoum core just release a 3.0 pre-version and I have some project that using this bundle for functional testing. Actually, I can test it with PHP 7.1.

Atoum doesn't have BC between the branch 2.x and 3.x.

So, we can allow the bundle to use one of these versions to add compatibility with PHP 7.1