### PR TITLE
Rename reserved "object" to "phpObject"; fixes atoum/atoum@b2bc07c

### DIFF
--- a/Test/Asserters/Crawler.php
+++ b/Test/Asserters/Crawler.php
@@ -6,7 +6,7 @@ use mageekguy\atoum;
 use mageekguy\atoum\asserter;
 use mageekguy\atoum\asserters;
 
-class Crawler extends asserters\object
+class Crawler extends asserters\phpObject
 {
     /**
      * @param mixed $value

--- a/Test/Asserters/Response.php
+++ b/Test/Asserters/Response.php
@@ -5,7 +5,7 @@ namespace atoum\AtoumBundle\Test\Asserters;
 use mageekguy\atoum;
 use mageekguy\atoum\asserters;
 
-class Response extends asserters\object
+class Response extends asserters\phpObject
 {
     /**
      * @param mixed $value

--- a/tests/units/Test/Asserters/Crawler.php
+++ b/tests/units/Test/Asserters/Crawler.php
@@ -9,7 +9,7 @@ class Crawler extends atoum\test
 {
     public function testClass()
     {
-        $this->testedClass->isSubclassOf('\\mageekguy\\atoum\\asserters\\object');
+        $this->testedClass->isSubclassOf('\\mageekguy\\atoum\\asserters\\phpObject');
     }
 
     public function test__construct()

--- a/tests/units/Test/Asserters/Element.php
+++ b/tests/units/Test/Asserters/Element.php
@@ -10,7 +10,7 @@ class Element extends atoum\test
 {
     public function testClass()
     {
-        $this->testedClass->isSubclassOf('\\mageekguy\\atoum\\asserters\\object');
+        $this->testedClass->isSubclassOf('\\mageekguy\\atoum\\asserters\\phpObject');
     }
 
     public function test__construct()

--- a/tests/units/Test/Asserters/Response.php
+++ b/tests/units/Test/Asserters/Response.php
@@ -9,7 +9,7 @@ class Response extends atoum\test
 {
     public function testClass()
     {
-        $this->testedClass->isSubclassOf('\\mageekguy\\atoum\\asserters\\object');
+        $this->testedClass->isSubclassOf('\\mageekguy\\atoum\\asserters\\phpObject');
     }
 
     public function test__construct()


### PR DESCRIPTION
In PHP 7.2.0 object is a reserved name. You change it in atoum but not in bundle