### PR TITLE
[WIP] Symfony 4 compatibility

### DIFF
--- a/DependencyInjection/Compiler/BundleDirectoriesResolverPass.php
+++ b/DependencyInjection/Compiler/BundleDirectoriesResolverPass.php
@@ -26,11 +26,11 @@ class BundleDirectoriesResolverPass implements CompilerPassInterface
         $configuration   = $container->getParameterBag()->resolveValue($container->getParameter('atoum.bundles'));
 
         foreach ($configuration as $bundleName => $data) {
-            if (!isset($bundles[$bundleName])) {
+            if ($data['is_bundle'] && !isset($bundles[$bundleName])) {
                 throw new \LogicException(sprintf('Bundle "%s" does not exists.', $bundleName));
             }
 
-            $rc        = new \ReflectionClass($bundles[$bundleName]);
+            $rc        = new \ReflectionClass($data['is_bundle'] ? $bundles[$bundleName] : 'App\Kernel');
             $directory = dirname($rc->getFileName());
 
             $directories = array_map(

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -29,6 +29,9 @@ class Configuration implements ConfigurationInterface
                         ->useAttributeAsKey('name')
                         ->prototype('array')
                             ->children()
+                                ->booleanNode('is_bundle')
+                                    ->defaultTrue()
+                                ->end()
                                 ->arrayNode('directories')
                                     ->defaultValue(array(
                                         'Tests/Units', 'Tests/Controller',

--- a/Resources/config/services/configuration.xml
+++ b/Resources/config/services/configuration.xml
@@ -10,7 +10,10 @@
     </parameters>
 
     <services>
-        <service id="atoum.configuration.bundle.container" class="%atoum.configuration.bundle.container.class%">
+        <service id="atoum.configuration.bundle.container" class="%atoum.configuration.bundle.container.class%" public="true" />
+
+        <service id="atoum.command" class="atoum\AtoumBundle\Command\AtoumCommand">
+            <tag name="console.command" command="atoum" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
Add `is_bundle` option in the bundle configuration to be able to launch tests from a bundle-less application.

I don't know if it's the best way to go for it, but that's the solution I found at least.
I did the minimum necessary to make it work.